### PR TITLE
Homework 6 completed

### DIFF
--- a/external/startgrid.bat
+++ b/external/startgrid.bat
@@ -1,0 +1,8 @@
+set server_directory="C:\Users\79612\seleniumgrid"
+set chrome_driver_path="C:\Users\79612\seleniumgrid\chromedriver.exe"
+set gecko_driver_path="C:\Users\79612\seleniumgrid\geckodriver.exe"
+
+cd %server_directory%
+start java -jar .\selenium-server-standalone-3.141.59.jar -role hub
+start java "-Dwebdriver.gecko.driver=%gecko_driver_path%" -jar .\selenium-server-standalone-3.141.59.jar -role node -hub http://localhost:4444/grid/register -port 5558
+start java "-Dwebdriver.chrome.driver=%chrome_driver_path%" -jar .\selenium-server-standalone-3.141.59.jar -role node -hub http://localhost:4444/grid/register -port 5559

--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,13 @@
     </profile>
 
     <profile>
+      <id>hw5seleniumTests</id>
+      <properties>
+        <testng.suite.file>${testng.configs.path}/hw5seleniumTests.xml</testng.suite.file>
+      </properties>
+    </profile>
+
+    <profile>
       <id>hw6seleniumTests</id>
       <activation>
         <activeByDefault>true</activeByDefault>

--- a/pom.xml
+++ b/pom.xml
@@ -203,11 +203,18 @@
 
     <profile>
       <id>hw4seleniumTests</id>
+      <properties>
+        <testng.suite.file>${testng.configs.path}/hw4seleniumTests.xml</testng.suite.file>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>hw6seleniumTests</id>
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>
       <properties>
-        <testng.suite.file>${testng.configs.path}/hw4seleniumTests.xml</testng.suite.file>
+        <testng.suite.file>${testng.configs.path}/hw6seleniumTests.xml</testng.suite.file>
       </properties>
     </profile>
   </profiles>

--- a/src/main/java/di/DriverModule.java
+++ b/src/main/java/di/DriverModule.java
@@ -3,6 +3,7 @@ package di;
 import com.google.inject.AbstractModule;
 import io.github.bonigarcia.wdm.config.DriverManagerType;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.Properties;
 import lombok.SneakyThrows;
 
@@ -28,6 +29,9 @@ public class DriverModule extends AbstractModule {
 
     @SneakyThrows
     static String getBrowserNameFromConfig() {
+        if (Objects.nonNull(System.getProperty("browser.name"))) {
+            return System.getProperty("browser.name");
+        }
         Properties prop = new Properties();
         prop.loadFromXML(DriverModule.class.getResourceAsStream(DRIVER_CONFIG_PATH));
         return prop.getProperty(BROWSER_PROPERTY_NAME);

--- a/src/main/java/di/DriverSingleton.java
+++ b/src/main/java/di/DriverSingleton.java
@@ -1,18 +1,44 @@
 package di;
 
+import static org.openqa.selenium.remote.BrowserType.CHROME;
+import static org.openqa.selenium.remote.BrowserType.FIREFOX;
+
 import com.google.inject.AbstractModule;
 import com.google.inject.Singleton;
 import io.github.bonigarcia.wdm.WebDriverManager;
 import io.github.bonigarcia.wdm.config.DriverManagerType;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Objects;
 import lombok.SneakyThrows;
+import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.firefox.FirefoxOptions;
+import org.openqa.selenium.remote.RemoteWebDriver;
 
 public class DriverSingleton extends AbstractModule {
     @Override
     protected void configure() {
         DriverManagerType browserType = DriverModule.getBrowserType();
         WebDriverManager.getInstance(browserType).setup();
-        injectDriverAsSingleton(browserType);
+        if (Objects.isNull(System.getProperty("browser.remote"))) {
+            injectDriverAsSingleton(browserType);
+        } else {
+            injectRemoteDriverAsInstance(browserType);
+        }
+    }
+
+    private void injectRemoteDriverAsInstance(DriverManagerType browserType) {
+        Capabilities capabilities = getCapabilitiesForBrowserName(browserType.getBrowserName());
+        RemoteWebDriver remoteDriver = null;
+        try {
+            remoteDriver = new RemoteWebDriver(new URL("http://localhost:4444/wd/hub"), capabilities);
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException(e.getMessage());
+        }
+        bind(WebDriver.class)
+            .toInstance(remoteDriver);
     }
 
     @SneakyThrows
@@ -26,5 +52,17 @@ public class DriverSingleton extends AbstractModule {
     private void injectDriverAsInstance(DriverManagerType browserType) {
         bind(WebDriver.class)
             .toInstance((WebDriver) Class.forName(browserType.browserClass()).getConstructor().newInstance());
+    }
+
+    private Capabilities getCapabilitiesForBrowserName(String browserName) {
+        if (CHROME.equalsIgnoreCase(browserName)) {
+            return new ChromeOptions();
+        } else if (FIREFOX.equalsIgnoreCase(browserName)) {
+            return new FirefoxOptions();
+        } else {
+            throw new IllegalArgumentException(
+                String.format("Unsupported browser type %s for remote browser", browserName)
+            );
+        }
     }
 }

--- a/src/test/java/ru/training/at/hw6/tests/BaseJdiTestingIndexPageTest.java
+++ b/src/test/java/ru/training/at/hw6/tests/BaseJdiTestingIndexPageTest.java
@@ -1,0 +1,38 @@
+package ru.training.at.hw6.tests;
+
+import static com.google.inject.Guice.createInjector;
+
+import data.User;
+import di.DriverSingleton;
+import di.PropertiesModule;
+import driver.DriverWrapper;
+import org.openqa.selenium.WebDriver;
+import org.testng.ITestContext;
+import org.testng.ITestResult;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import ru.training.at.hw4.steps.ActionStep;
+import ru.training.at.hw4.steps.AssertionStep;
+
+public class BaseJdiTestingIndexPageTest {
+    protected ThreadLocal<DriverWrapper> driver = new ThreadLocal<>();
+    protected User user;
+    protected ActionStep actionStep;
+    protected AssertionStep assertionStep;
+
+    @BeforeMethod(alwaysRun = true)
+    public void beforeClassSetUp(ITestContext testContext) {
+        driver.set(new DriverWrapper(createInjector(new DriverSingleton()).getInstance(WebDriver.class)));
+        user = createInjector(new PropertiesModule()).getInstance(User.class);
+        actionStep = new ActionStep(driver.get());
+        assertionStep = new AssertionStep(driver.get());
+        testContext.setAttribute("driver", driver.get());
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void afterClassTearDown(ITestResult testResult) {
+        if (driver.get() != null) {
+            driver.get().quit();
+        }
+    }
+}

--- a/src/test/java/ru/training/at/hw6/tests/DifferentElementsPageTest.java
+++ b/src/test/java/ru/training/at/hw6/tests/DifferentElementsPageTest.java
@@ -1,0 +1,57 @@
+package ru.training.at.hw6.tests;
+
+import data.DifferentElementsPageData;
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
+import org.testng.annotations.Test;
+
+@Feature("Testing different elements page by selecting inputs and validating logs")
+public class DifferentElementsPageTest extends BaseJdiTestingIndexPageTest {
+
+    @Story("Selecting checkboxes, radio buttons and dropdown lists with log validation")
+    @Test
+    public void secondExerciseDifferentElementsTest() {
+
+        // 1. Open test site by URL
+        actionStep.openJdiTestingIndexPage();
+        assertionStep.indexPageIsOpenedCorrectlyByURL();
+
+        // 2. Assert Browser title
+        assertionStep.indexPageTitleIsCorrect();
+        // 3. Perform login
+        actionStep.performLogin(user.getLogin(), user.getPassword());
+
+        // 4. Assert Username is loggined
+        assertionStep.usernameIsLoggedInSuccessfully(user.getUsername());
+
+        // 5. Open through the header menu Service -> Different Elements Page
+        actionStep.openDifferentElementsPage();
+        assertionStep.dePageTitleIsCorrect();
+
+        // 6. Select checkboxes
+        actionStep.selectCheckboxesByValues(
+            DifferentElementsPageData.WATER_CHECKBOX_LABEL,
+            DifferentElementsPageData.WIND_CHECKBOX_LABEL
+        );
+
+        assertionStep.checkboxesSelectedCorrectly(
+            DifferentElementsPageData.WATER_CHECKBOX_LABEL,
+            DifferentElementsPageData.WIND_CHECKBOX_LABEL
+        );
+
+        // 7. Select radio
+        actionStep.selectRadioButton(DifferentElementsPageData.SELEN);
+        assertionStep.radioButtonSelectedCorrectly(DifferentElementsPageData.SELEN);
+
+        // 8. Select in dropdown
+        actionStep.selectDropdownList(DifferentElementsPageData.YELLOW);
+        assertionStep.dropdownListValueIsCorrect(DifferentElementsPageData.YELLOW);
+
+        /* 9. Assert that
+                for each checkbox there is an individual log row and value is corresponded to the status of checkbox
+                for radio button there is a log row and value is corresponded to the status of radio button
+                for dropdown there is a log row and value is corresponded to the selected value.
+        */
+        assertionStep.logsAreCorrect();
+    }
+}

--- a/src/test/java/ru/training/at/hw6/tests/GeneralItemPlacementTest.java
+++ b/src/test/java/ru/training/at/hw6/tests/GeneralItemPlacementTest.java
@@ -1,0 +1,49 @@
+package ru.training.at.hw6.tests;
+
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
+import org.testng.annotations.Test;
+
+@Feature("Testing index page for correct placement of elements")
+public class GeneralItemPlacementTest extends BaseJdiTestingIndexPageTest {
+
+    @Story("Checking the content of navbar, sidebar, iframe and benefit group")
+    @Test
+    public void firstExerciseItemPlacementTest() {
+
+        // 1. Open test site by URL
+        actionStep.openJdiTestingIndexPage();
+        assertionStep.indexPageIsOpenedCorrectlyByURL();
+
+        // 2. Assert Browser title
+        assertionStep.indexPageTitleIsCorrect();
+
+        // 3. Perform login
+        actionStep.performLogin(user.getLogin(), user.getPassword());
+
+        // 4. Assert Username is loggined
+        assertionStep.usernameIsLoggedInSuccessfully(user.getUsername());
+
+        // 5. Assert that there are 4 items on the header section are displayed and they have proper texts
+        assertionStep.headerNavbarIsDisplayedWithProperTexts();
+
+        // 6. Assert that there are 4 images on the Index Page and they are displayed
+        // 7. Assert that there are 4 texts on the Index Page under icons and they have proper text
+        assertionStep.benefitGroupItemsAreDisplayedWithProperContent();
+
+        // 8. Assert that there is the iframe with “Frame Button” exist
+        assertionStep.thereIsAFrameWithButton();
+
+        // 9. Switch to the iframe and check that there is “Frame Button” in the iframe
+        actionStep.getIframeInScope();
+        assertionStep.iframeWithButtonInScope();
+
+        // 10. Switch to original window back
+        actionStep.getWindowInScope();
+        assertionStep.windowInScope();
+
+        // 11. Assert that there are 5 items in the Left Section are displayed and they have proper text
+        assertionStep.sidebarNavIsDisplayedWithProperTexts();
+    }
+
+}

--- a/src/test/resources/testngconfigs/hw6seleniumTests.xml
+++ b/src/test/resources/testngconfigs/hw6seleniumTests.xml
@@ -1,0 +1,8 @@
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
+<suite name="hw6seleniumTests">
+  <test name="jdiTestingPagesTest">
+    <packages>
+      <package name="ru.training.at.hw6.tests"/>
+    </packages>
+  </test>
+</suite>


### PR DESCRIPTION
If you use Windows to start the selenium grid (hub and nodes) you can use `external/startgrid.bat` by setting the required paths:
```bat
set server_directory="C:\Users\79612\seleniumgrid"
set chrome_driver_path="C:\Users\79612\seleniumgrid\chromedriver.exe"
set gecko_driver_path="C:\Users\79612\seleniumgrid\geckodriver.exe"
```

After that, you can run `hw6` test with the following command
```mvn
mvn -Dbrowser.name=Firefox -Dbrowser.remote=true clean test

```

Only `chrome` and `firefox` drivers are supported in the remote mode.